### PR TITLE
Replace pcapy with pcapy-ng

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - |
     if python --version 2>&1 | grep -E '^Python 3($|[.])'; then
         sudo apt-get install libpcap-dev
-        pip install pcapy
+        pip install pcapy-ng
         python -c 'import pcapy'
     fi
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         # OS package manager if possible.
         # #'pylibcap ; python_version<"3"',
         # This one should work on py2 as well though.
-        'pcapy ; python_version>="3"',
+        'pcapy-ng ; python_version>="3"',
     ],
 )
 


### PR DESCRIPTION
Pcapy is no longer maintained and causes issues with newer python versions.